### PR TITLE
Dev 1106 improve token queries to use jwt instead of hashed tokens

### DIFF
--- a/app/models/jwk_key.ts
+++ b/app/models/jwk_key.ts
@@ -14,7 +14,7 @@ export interface PublicKeyData {
 
 export default class JwkKey extends BaseModel {
   @column({ isPrimary: true })
-  declare kid: string
+  declare id: string
 
   @column()
   declare keyType: string

--- a/app/models/oauth_access_token.ts
+++ b/app/models/oauth_access_token.ts
@@ -10,7 +10,7 @@ export default class OAuthAccessToken extends BaseModel {
   static table = 'oauth_access_tokens'
 
   @column({ isPrimary: true })
-  declare tokenHash: string
+  declare id: string
 
   @column()
   declare clientId: string
@@ -46,6 +46,6 @@ export default class OAuthAccessToken extends BaseModel {
   @belongsTo(() => Organization, { foreignKey: 'organizationId' })
   declare organization: BelongsTo<typeof Organization>
 
-  @hasOne(() => OAuthRefreshToken, { foreignKey: 'accessTokenHash', localKey: 'tokenHash' })
+  @hasOne(() => OAuthRefreshToken, { foreignKey: 'accessTokenId' })
   declare refreshToken: HasOne<typeof OAuthRefreshToken>
 }

--- a/app/models/oauth_authorization_code.ts
+++ b/app/models/oauth_authorization_code.ts
@@ -9,7 +9,7 @@ export default class OAuthAuthorizationCode extends BaseModel {
   static table = 'oauth_authorization_codes'
 
   @column({ isPrimary: true })
-  declare codeHash: string
+  declare id: string
 
   @column()
   declare clientId: string

--- a/app/models/oauth_client.ts
+++ b/app/models/oauth_client.ts
@@ -11,7 +11,7 @@ export default class OAuthClient extends BaseModel {
   static table = 'oauth_clients'
 
   @column({ isPrimary: true })
-  declare clientId: string
+  declare id: string
 
   @column()
   declare clientSecretHash: string

--- a/app/models/oauth_consent.ts
+++ b/app/models/oauth_consent.ts
@@ -41,6 +41,6 @@ export default class OauthConsent extends BaseModel {
   @belongsTo(() => User, { foreignKey: 'userId' })
   declare user: BelongsTo<typeof User>
 
-  @belongsTo(() => OauthClient, { foreignKey: 'clientId', localKey: 'clientId' })
+  @belongsTo(() => OauthClient, { foreignKey: 'clientId' })
   declare client: BelongsTo<typeof OauthClient>
 }

--- a/app/models/oauth_refresh_token.ts
+++ b/app/models/oauth_refresh_token.ts
@@ -10,10 +10,10 @@ export default class OAuthRefreshToken extends BaseModel {
   static table = 'oauth_refresh_tokens'
 
   @column({ isPrimary: true })
-  declare tokenHash: string
+  declare id: string
 
   @column()
-  declare accessTokenHash: string
+  declare accessTokenId: string
 
   @column()
   declare clientId: string
@@ -49,6 +49,6 @@ export default class OAuthRefreshToken extends BaseModel {
   @belongsTo(() => Organization, { foreignKey: 'organizationId' })
   declare organization: BelongsTo<typeof Organization>
 
-  @belongsTo(() => OAuthAccessToken, { foreignKey: 'accessTokenHash', localKey: 'tokenHash' })
+  @belongsTo(() => OAuthAccessToken, { foreignKey: 'accessTokenId' })
   declare accessToken: BelongsTo<typeof OAuthAccessToken>
 }

--- a/app/repositories/oauth_authorization_code_repository.ts
+++ b/app/repositories/oauth_authorization_code_repository.ts
@@ -1,6 +1,5 @@
 import OAuthAuthorizationCode from '#models/oauth_authorization_code'
 import { DateTime } from 'luxon'
-import hash from '@adonisjs/core/services/hash'
 
 export default class OAuthAuthorizationCodeRepository {
   /**
@@ -12,25 +11,17 @@ export default class OAuthAuthorizationCodeRepository {
   }
 
   /**
-   * Retrieves an OAuthAuthorizationCode instance by its code hash.
+   * Retrieves an OAuthAuthorizationCode instance by its UUID.
    */
-  public async findByCodeHash(codeHash: string): Promise<OAuthAuthorizationCode | null> {
-    return OAuthAuthorizationCode.find(codeHash)
+  public async findByCode(code: string): Promise<OAuthAuthorizationCode | null> {
+    return OAuthAuthorizationCode.find(code)
   }
 
   /**
-   * Creates a new OAuthAuthorizationCode instance with hashed code.
+   * Creates a new OAuthAuthorizationCode instance (UUID generated automatically).
    */
-  public async create(
-    data: Partial<OAuthAuthorizationCode> & { code: string }
-  ): Promise<OAuthAuthorizationCode> {
-    const { code, ...codeData } = data
-    const codeHash = await hash.make(code)
-
-    return OAuthAuthorizationCode.create({
-      ...codeData,
-      codeHash,
-    })
+  public async create(data: Partial<OAuthAuthorizationCode>): Promise<OAuthAuthorizationCode> {
+    return OAuthAuthorizationCode.create(data)
   }
 
   /**
@@ -56,22 +47,10 @@ export default class OAuthAuthorizationCodeRepository {
   }
 
   /**
-   * Marks a code as used by code hash.
-   */
-  public async markAsUsedByCode(code: string): Promise<OAuthAuthorizationCode | null> {
-    const codeRecord = await this.findByCode(code)
-    if (!codeRecord) {
-      return null
-    }
-
-    return this.markAsUsed(codeRecord.codeHash)
-  }
-
-  /**
    * Marks an authorization code as used.
    */
-  public async markAsUsed(codeHash: string): Promise<OAuthAuthorizationCode | null> {
-    const authCode = await this.findByCodeHash(codeHash)
+  public async markAsUsed(codeId: string): Promise<OAuthAuthorizationCode | null> {
+    const authCode = await this.findByCode(codeId)
     if (!authCode) {
       return null
     }
@@ -94,35 +73,26 @@ export default class OAuthAuthorizationCodeRepository {
   }
 
   /**
-   * Deletes an OAuthAuthorizationCode instance by its code hash.
+   * Deletes an OAuthAuthorizationCode instance by its code ID.
    */
-  public async delete(codeHash: string): Promise<void> {
-    const modelInstance = await this.findByCodeHash(codeHash)
+  public async delete(codeId: string): Promise<void> {
+    const modelInstance = await this.findByCode(codeId)
     if (modelInstance) {
       await modelInstance.delete()
     }
   }
 
   /**
-   * Finds an authorization code by the actual code value (validates hash).
+   * Finds an authorization code with relations - PERFORMANCE FIX: Direct UUID lookup.
    */
-  public async findByCode(code: string): Promise<OAuthAuthorizationCode | null> {
-    try {
-      const potentialMatches = await OAuthAuthorizationCode.query()
-        .where('is_used', false)
-        .where('expires_at', '>', DateTime.now().toSQL())
-        .preload('user')
-        .preload('client')
-
-      for (const codeRecord of potentialMatches) {
-        const isValid = await hash.verify(codeRecord.codeHash, code)
-        if (isValid) {
-          return codeRecord
-        }
-      }
-      return null
-    } catch {
-      return null
-    }
+  public async findByCodeWithRelations(code: string): Promise<OAuthAuthorizationCode | null> {
+    return OAuthAuthorizationCode.query()
+      .where('id', code)
+      .where('is_used', false)
+      .where('expires_at', '>', DateTime.now().toSQL())
+      .preload('user')
+      .preload('client')
+      .preload('organization')
+      .first()
   }
 }

--- a/app/repositories/oauth_client_repository.ts
+++ b/app/repositories/oauth_client_repository.ts
@@ -11,7 +11,7 @@ export default class OAuthClientRepository {
   }
 
   /**
-   * Retrieves an OAuthClient instance by its client ID.
+   * Retrieves an OAuthClient instance by its UUID.
    */
   public async findById(clientId: string): Promise<OAuthClient | null> {
     return OAuthClient.findBy({ id: clientId })

--- a/app/repositories/oauth_client_repository.ts
+++ b/app/repositories/oauth_client_repository.ts
@@ -14,7 +14,7 @@ export default class OAuthClientRepository {
    * Retrieves an OAuthClient instance by its client ID.
    */
   public async findById(clientId: string): Promise<OAuthClient | null> {
-    return OAuthClient.find(clientId)
+    return OAuthClient.findBy({ id: clientId })
   }
 
   /**

--- a/app/services/code_generator_service.ts
+++ b/app/services/code_generator_service.ts
@@ -1,11 +1,6 @@
 import { inject } from '@adonisjs/core'
 import crypto from 'node:crypto'
 
-export interface TokenPair {
-  accessToken: string
-  refreshToken: string
-}
-
 @inject()
 export default class CodeGeneratorService {
   /**
@@ -22,45 +17,7 @@ export default class CodeGeneratorService {
   }
 
   /**
-   * Generate a secure authorization code
-   */
-  generateAuthorizationCode(): string {
-    return this.generateSecureCode()
-  }
-
-  /**
-   * Generate a secure access token
-   */
-  generateAccessToken(): string {
-    return this.generateSecureCode()
-  }
-
-  /**
-   * Generate a secure refresh token
-   */
-  generateRefreshToken(): string {
-    return this.generateSecureCode()
-  }
-
-  /**
-   * Generate both access and refresh tokens
-   */
-  generateTokenPair(): TokenPair {
-    return {
-      accessToken: this.generateAccessToken(),
-      refreshToken: this.generateRefreshToken(),
-    }
-  }
-
-  /**
-   * Generate a unique authorization code (alias for consistency)
-   */
-  generateUniqueCode(): string {
-    return this.generateAuthorizationCode()
-  }
-
-  /**
-   * Generate a secure password
+   * Generate a secure password for database instances
    */
   generatePassword(length: number = 16): string {
     return this.generateSecureCode(length)

--- a/app/services/oauth_authorization_service.ts
+++ b/app/services/oauth_authorization_service.ts
@@ -60,7 +60,7 @@ export default class OAuthAuthorizationService {
     }
 
     // Check if consent is needed
-    const needsConsent = await this.consentService.needsConsent(user.id, client.clientId, scopes)
+    const needsConsent = await this.consentService.needsConsent(user.id, client.id, scopes)
     if (!needsConsent) {
       const redirectUrl = await this.autoApprovalService.approve({
         user,

--- a/database/factories/oauth_client_factory.ts
+++ b/database/factories/oauth_client_factory.ts
@@ -10,7 +10,8 @@ export const OAuthClientFactory = factory
     const clientSecretHash = await hash.make(clientSecret)
 
     return {
-      clientId: faker.string.uuid(),
+      // Use predictable UUID for testing consistency
+      id: faker.string.uuid(),
       clientSecretHash: clientSecretHash,
       clientName: faker.company.name(),
       redirectUris: ['https://example.com/callback'],

--- a/database/migrations/1750103550425_create_oauth_clients_table.ts
+++ b/database/migrations/1750103550425_create_oauth_clients_table.ts
@@ -5,7 +5,11 @@ export default class extends BaseSchema {
 
   async up() {
     this.schema.createTable(this.tableName, (table) => {
-      table.string('client_id').primary()
+      table
+        .uuid('id')
+        .primary()
+        .defaultTo(this.db.rawQuery('gen_random_uuid()').knexQuery)
+        .notNullable()
       table.string('client_secret_hash', 1000).notNullable()
       table.string('client_name').notNullable()
       table.specificType('redirect_uris', 'text[]').notNullable()

--- a/database/migrations/1750103594350_create_oauth_authorization_codes_table.ts
+++ b/database/migrations/1750103594350_create_oauth_authorization_codes_table.ts
@@ -5,8 +5,12 @@ export default class extends BaseSchema {
 
   async up() {
     this.schema.createTable(this.tableName, (table) => {
-      table.string('code_hash').primary()
-      table.string('client_id').references('client_id').inTable('oauth_clients').onDelete('CASCADE')
+      table
+        .uuid('id')
+        .primary()
+        .defaultTo(this.db.rawQuery('gen_random_uuid()').knexQuery)
+        .notNullable()
+      table.uuid('client_id').references('id').inTable('oauth_clients').onDelete('CASCADE')
       table.uuid('user_id').references('id').inTable('users').onDelete('CASCADE')
       table
         .uuid('organization_id')

--- a/database/migrations/1750103628451_create_oauth_access_tokens_table.ts
+++ b/database/migrations/1750103628451_create_oauth_access_tokens_table.ts
@@ -5,8 +5,12 @@ export default class extends BaseSchema {
 
   async up() {
     this.schema.createTable(this.tableName, (table) => {
-      table.string('token_hash').primary()
-      table.string('client_id').references('client_id').inTable('oauth_clients').onDelete('CASCADE')
+      table
+        .uuid('id')
+        .primary()
+        .defaultTo(this.db.rawQuery('gen_random_uuid()').knexQuery)
+        .notNullable()
+      table.uuid('client_id').references('id').inTable('oauth_clients').onDelete('CASCADE')
       table.uuid('user_id').references('id').inTable('users').onDelete('CASCADE')
       table
         .uuid('organization_id')
@@ -26,7 +30,7 @@ export default class extends BaseSchema {
       table.index(['organization_id', 'user_id'])
       table.index(['organization_id', 'client_id'])
       table.index('is_revoked')
-      table.index(['token_hash', 'is_revoked', 'expires_at']) // Composite for fast validation
+      table.index(['id', 'is_revoked', 'expires_at']) // Composite for fast validation
     })
   }
 

--- a/database/migrations/1750103645139_create_oauth_refresh_tokens_table.ts
+++ b/database/migrations/1750103645139_create_oauth_refresh_tokens_table.ts
@@ -5,13 +5,17 @@ export default class extends BaseSchema {
 
   async up() {
     this.schema.createTable(this.tableName, (table) => {
-      table.string('token_hash').primary()
       table
-        .string('access_token_hash')
-        .references('token_hash')
+        .uuid('id')
+        .primary()
+        .defaultTo(this.db.rawQuery('gen_random_uuid()').knexQuery)
+        .notNullable()
+      table
+        .uuid('access_token_id')
+        .references('id')
         .inTable('oauth_access_tokens')
         .onDelete('CASCADE')
-      table.string('client_id').references('client_id').inTable('oauth_clients').onDelete('CASCADE')
+      table.uuid('client_id').references('id').inTable('oauth_clients').onDelete('CASCADE')
       table.uuid('user_id').references('id').inTable('users').onDelete('CASCADE')
       table
         .uuid('organization_id')
@@ -31,7 +35,7 @@ export default class extends BaseSchema {
       table.index(['organization_id', 'user_id'])
       table.index(['organization_id', 'client_id'])
       table.index('is_revoked')
-      table.index('access_token_hash') // For token rotation
+      table.index('access_token_id') // For token rotation
     })
   }
 

--- a/database/migrations/1750103719497_create_jwk_keys_table.ts
+++ b/database/migrations/1750103719497_create_jwk_keys_table.ts
@@ -5,7 +5,11 @@ export default class extends BaseSchema {
 
   async up() {
     this.schema.createTable(this.tableName, (table) => {
-      table.string('kid').primary().notNullable() // Key ID
+      table
+        .uuid('id')
+        .primary()
+        .defaultTo(this.db.rawQuery('gen_random_uuid()').knexQuery)
+        .notNullable()
       table.string('key_type').notNullable() // kty (RSA, EC)
       table.string('algorithm').notNullable() // alg (RS256, ES256)
       table.string('use').notNullable() // use (sig, enc)

--- a/database/migrations/1750874262385_create_create_oauth_consents_table.ts
+++ b/database/migrations/1750874262385_create_create_oauth_consents_table.ts
@@ -13,9 +13,9 @@ export default class extends BaseSchema {
 
       table.uuid('user_id').notNullable().references('id').inTable('users').onDelete('CASCADE')
       table
-        .string('client_id')
+        .uuid('client_id')
         .notNullable()
-        .references('client_id')
+        .references('id')
         .inTable('oauth_clients')
         .onDelete('CASCADE')
       table.specificType('scopes', 'text[]').notNullable()

--- a/database/seeders/oauth_client_seeder.ts
+++ b/database/seeders/oauth_client_seeder.ts
@@ -5,14 +5,13 @@ import { BaseSeeder } from '@adonisjs/lucid/seeders'
 export default class extends BaseSeeder {
   async run() {
     await OAuthClient.create({
-      id: '2cfb378e-e728-4c95-b92d-fc69965b00cf',
       accessTokenLifetime: 3600,
       refreshTokenLifetime: 2592000,
       isTrusted: true,
       grantTypes: ['authorization_code', 'refresh_token'],
       redirectUris: [env.get('OAUTH_REDIRECT_URI', 'http://localhost:4000/api/oauth/callback')],
       clientName: env.get('TIP_NAME'),
-      clientId: env.get('OAUTH_CLIENT_ID'),
+      id: env.get('OAUTH_CLIENT_ID'),
       clientSecretHash: env.get('OAUTH_CLIENT_SECRET_HASH'),
     })
   }

--- a/database/seeders/oauth_client_seeder.ts
+++ b/database/seeders/oauth_client_seeder.ts
@@ -5,6 +5,7 @@ import { BaseSeeder } from '@adonisjs/lucid/seeders'
 export default class extends BaseSeeder {
   async run() {
     await OAuthClient.create({
+      id: '2cfb378e-e728-4c95-b92d-fc69965b00cf',
       accessTokenLifetime: 3600,
       refreshTokenLifetime: 2592000,
       isTrusted: true,

--- a/tests/functional/oauth_flow.spec.ts
+++ b/tests/functional/oauth_flow.spec.ts
@@ -30,7 +30,7 @@ test.group('OAuth Flow', (group) => {
     const response = await client
       .get('/oauth/authorize')
       .qs({
-        client_id: testClient.clientId,
+        client_id: testClient.id,
         response_type: 'code',
         redirect_uri: testClient.redirectUris[0],
         scope: 'read write',
@@ -47,7 +47,7 @@ test.group('OAuth Flow', (group) => {
     const response = await client
       .get('/oauth/authorize')
       .qs({
-        client_id: trustedClient.clientId,
+        client_id: trustedClient.id,
         response_type: 'code',
         redirect_uri: trustedClient.redirectUris[0],
         state: 'test-state-123',
@@ -61,7 +61,7 @@ test.group('OAuth Flow', (group) => {
     const response = await client
       .get('/oauth/authorize')
       .qs({
-        client_id: 'invalid-client-id',
+        client_id: '00000000-0000-0000-0000-000000000000', // Valid UUID format that doesn't exist
         response_type: 'code',
         redirect_uri: testClient.redirectUris[0],
       })
@@ -77,7 +77,7 @@ test.group('OAuth Flow', (group) => {
     const response = await client
       .get('/oauth/authorize')
       .qs({
-        client_id: testClient.clientId,
+        client_id: testClient.id,
         response_type: 'code',
         redirect_uri: 'https://malicious-site.com/callback',
       })
@@ -93,7 +93,7 @@ test.group('OAuth Flow', (group) => {
     const response = await client
       .get('/oauth/authorize')
       .qs({
-        client_id: testClient.clientId,
+        client_id: testClient.id,
         response_type: 'token', // Not supported
         redirect_uri: testClient.redirectUris[0],
       })
@@ -131,7 +131,7 @@ test.group('OAuth Flow', (group) => {
     const response = await client
       .get('/oauth/authorize')
       .qs({
-        client_id: testClient.clientId,
+        client_id: testClient.id,
         redirect_uri: 'https://example.com/callback',
       })
       .loginAs(testUser)
@@ -150,7 +150,7 @@ test.group('OAuth Flow', (group) => {
     const response = await client
       .get('/oauth/authorize')
       .qs({
-        client_id: testClient.clientId,
+        client_id: testClient.id,
         response_type: 'code',
       })
       .loginAs(testUser)
@@ -175,7 +175,7 @@ test.group('OAuth Flow', (group) => {
     const response1 = await client
       .get('/oauth/authorize')
       .qs({
-        client_id: multiUriClient.clientId,
+        client_id: multiUriClient.id,
         response_type: 'code',
         redirect_uri: 'https://example.com/callback',
       })
@@ -187,7 +187,7 @@ test.group('OAuth Flow', (group) => {
     const response2 = await client
       .get('/oauth/authorize')
       .qs({
-        client_id: multiUriClient.clientId,
+        client_id: multiUriClient.id,
         response_type: 'code',
         redirect_uri: 'https://app.example.com/oauth/callback',
       })
@@ -200,7 +200,7 @@ test.group('OAuth Flow', (group) => {
     // Create persistent consent for this user/client combination
     await OauthConsent.create({
       userId: testUser.id,
-      clientId: testClient.clientId,
+      clientId: testClient.id,
       scopes: [
         Object.keys(oauthScopesConfig.scopes)[0], // database:read
         Object.keys(oauthScopesConfig.scopes)[1], // database:write
@@ -213,7 +213,7 @@ test.group('OAuth Flow', (group) => {
     const response = await client
       .get('/oauth/authorize')
       .qs({
-        client_id: testClient.clientId,
+        client_id: testClient.id,
         response_type: 'code',
         redirect_uri: testClient.redirectUris[0],
         scope: `${Object.keys(oauthScopesConfig.scopes)[0]} ${Object.keys(oauthScopesConfig.scopes)[1]}`,
@@ -229,7 +229,7 @@ test.group('OAuth Flow', (group) => {
     // Create expired consent
     await OauthConsent.create({
       userId: testUser.id,
-      clientId: testClient.clientId,
+      clientId: testClient.id,
       scopes: [Object.keys(oauthScopesConfig.scopes)[0]], // database:read
       grantedAt: DateTime.now().minus({ days: 60 }),
       expiresAt: DateTime.now().minus({ days: 30 }), // Expired 30 days ago
@@ -239,7 +239,7 @@ test.group('OAuth Flow', (group) => {
     const response = await client
       .get('/oauth/authorize')
       .qs({
-        client_id: testClient.clientId,
+        client_id: testClient.id,
         response_type: 'code',
         redirect_uri: testClient.redirectUris[0],
         scope: Object.keys(oauthScopesConfig.scopes)[0], // database:read
@@ -255,7 +255,7 @@ test.group('OAuth Flow', (group) => {
     // Create revoked consent
     await OauthConsent.create({
       userId: testUser.id,
-      clientId: testClient.clientId,
+      clientId: testClient.id,
       scopes: [Object.keys(oauthScopesConfig.scopes)[0]], // database:read
       grantedAt: DateTime.now(),
       expiresAt: DateTime.now().plus({ days: 30 }),
@@ -265,7 +265,7 @@ test.group('OAuth Flow', (group) => {
     const response = await client
       .get('/oauth/authorize')
       .qs({
-        client_id: testClient.clientId,
+        client_id: testClient.id,
         response_type: 'code',
         redirect_uri: testClient.redirectUris[0],
         scope: Object.keys(oauthScopesConfig.scopes)[0], // database:read
@@ -283,7 +283,7 @@ test.group('OAuth Flow', (group) => {
     // Create consent for limited scope
     await OauthConsent.create({
       userId: testUser.id,
-      clientId: testClient.clientId,
+      clientId: testClient.id,
       scopes: [Object.keys(oauthScopesConfig.scopes)[0]], // database:read
       grantedAt: DateTime.now(),
       expiresAt: DateTime.now().plus({ days: 30 }),
@@ -293,7 +293,7 @@ test.group('OAuth Flow', (group) => {
     const response = await client
       .get('/oauth/authorize')
       .qs({
-        client_id: testClient.clientId,
+        client_id: testClient.id,
         response_type: 'code',
         redirect_uri: testClient.redirectUris[0],
         scope: `${Object.keys(oauthScopesConfig.scopes)[0]} ${Object.keys(oauthScopesConfig.scopes)[1]}`, // Requesting broader scope
@@ -309,7 +309,7 @@ test.group('OAuth Flow', (group) => {
     // Create consent for broad scope
     await OauthConsent.create({
       userId: testUser.id,
-      clientId: testClient.clientId,
+      clientId: testClient.id,
       scopes: [
         Object.keys(oauthScopesConfig.scopes)[0], // database:read
         Object.keys(oauthScopesConfig.scopes)[1], // database:write
@@ -323,7 +323,7 @@ test.group('OAuth Flow', (group) => {
     const response = await client
       .get('/oauth/authorize')
       .qs({
-        client_id: testClient.clientId,
+        client_id: testClient.id,
         response_type: 'code',
         redirect_uri: testClient.redirectUris[0],
         scope: Object.keys(oauthScopesConfig.scopes)[0], // Requesting subset
@@ -417,7 +417,7 @@ test.group('OAuth JIT Provisioning', (group) => {
     const idTokenHint = await createValidJWT(jwtData)
 
     const response = await client.get('/oauth/authorize').qs({
-      client_id: testClient.clientId,
+      client_id: testClient.id,
       response_type: 'code',
       redirect_uri: testClient.redirectUris[0],
       scope: Object.keys(oauthScopesConfig.scopes)[0], // database:read
@@ -453,7 +453,7 @@ test.group('OAuth JIT Provisioning', (group) => {
     const idTokenHint = await createValidJWT(jwtData)
 
     const response = await client.get('/oauth/authorize').qs({
-      client_id: testClient.clientId,
+      client_id: testClient.id,
       response_type: 'code',
       redirect_uri: testClient.redirectUris[0],
       scope: Object.keys(oauthScopesConfig.scopes)[0], // database:read
@@ -488,7 +488,7 @@ test.group('OAuth JIT Provisioning', (group) => {
     const idTokenHint = await createValidJWT(jwtData)
 
     const response = await client.get('/oauth/authorize').qs({
-      client_id: testClient.clientId,
+      client_id: testClient.id,
       response_type: 'code',
       redirect_uri: testClient.redirectUris[0],
       scope: Object.keys(oauthScopesConfig.scopes)[0], // database:read
@@ -518,7 +518,7 @@ test.group('OAuth JIT Provisioning', (group) => {
     const idTokenHint = await createValidJWT(jwtData)
 
     const response = await client.get('/oauth/authorize').qs({
-      client_id: trustedClient.clientId,
+      client_id: trustedClient.id,
       response_type: 'code',
       redirect_uri: trustedClient.redirectUris[0],
       scope: Object.keys(oauthScopesConfig.scopes)[0], // database:read
@@ -538,7 +538,7 @@ test.group('OAuth JIT Provisioning', (group) => {
     const invalidToken = 'invalid.jwt.token'
 
     const response = await client.get('/oauth/authorize').qs({
-      client_id: testClient.clientId,
+      client_id: testClient.id,
       response_type: 'code',
       redirect_uri: testClient.redirectUris[0],
       scope: Object.keys(oauthScopesConfig.scopes)[0], // database:read
@@ -559,7 +559,7 @@ test.group('OAuth JIT Provisioning', (group) => {
     const idTokenHint = await createValidJWT(jwtData)
 
     const response = await client.get('/oauth/authorize').qs({
-      client_id: testClient.clientId,
+      client_id: testClient.id,
       response_type: 'code',
       redirect_uri: testClient.redirectUris[0],
       scope: Object.keys(oauthScopesConfig.scopes)[0], // database:read
@@ -584,7 +584,7 @@ test.group('OAuth JIT Provisioning', (group) => {
     const response = await client
       .get('/oauth/authorize')
       .qs({
-        client_id: testClient.clientId,
+        client_id: testClient.id,
         response_type: 'code',
         redirect_uri: testClient.redirectUris[0],
         scope: Object.keys(oauthScopesConfig.scopes)[0], // database:read
@@ -604,7 +604,7 @@ test.group('OAuth JIT Provisioning', (group) => {
     const malformedToken = 'not.a.jwt'
 
     const response = await client.get('/oauth/authorize').qs({
-      client_id: testClient.clientId,
+      client_id: testClient.id,
       response_type: 'code',
       redirect_uri: testClient.redirectUris[0],
       scope: Object.keys(oauthScopesConfig.scopes)[0], // database:read
@@ -715,7 +715,7 @@ test.group('OAuth JIT Organization Provisioning', (group) => {
     const idTokenHint = await createValidJWTWithOrganization(jwtData)
 
     const response = await client.get('/oauth/authorize').qs({
-      client_id: testClient.clientId,
+      client_id: testClient.id,
       response_type: 'code',
       redirect_uri: testClient.redirectUris[0],
       scope: Object.keys(oauthScopesConfig.scopes)[0], // database:read
@@ -788,7 +788,7 @@ test.group('OAuth JIT Organization Provisioning', (group) => {
     const idTokenHint = await createValidJWTWithOrganization(jwtData)
 
     const response = await client.get('/oauth/authorize').qs({
-      client_id: testClient.clientId,
+      client_id: testClient.id,
       response_type: 'code',
       redirect_uri: testClient.redirectUris[0],
       scope: Object.keys(oauthScopesConfig.scopes)[0], // database:read
@@ -859,7 +859,7 @@ test.group('OAuth JIT Organization Provisioning', (group) => {
     const idTokenHint = await createValidJWTWithOrganization(jwtData)
 
     const response = await client.get('/oauth/authorize').qs({
-      client_id: testClient.clientId,
+      client_id: testClient.id,
       response_type: 'code',
       redirect_uri: testClient.redirectUris[0],
       scope: Object.keys(oauthScopesConfig.scopes)[0], // database:read
@@ -928,7 +928,7 @@ test.group('OAuth JIT Organization Provisioning', (group) => {
     const idTokenHint = await createValidJWTWithOrganization(jwtData)
 
     const response = await client.get('/oauth/authorize').qs({
-      client_id: testClient.clientId,
+      client_id: testClient.id,
       response_type: 'code',
       redirect_uri: testClient.redirectUris[0],
       scope: Object.keys(oauthScopesConfig.scopes)[0], // database:read
@@ -970,7 +970,7 @@ test.group('OAuth JIT Organization Provisioning', (group) => {
 
     // Step 1: Get authorization code (should auto-approve for trusted client)
     const authResponse = await client.get('/oauth/authorize').qs({
-      client_id: trustedClient.clientId,
+      client_id: trustedClient.id,
       response_type: 'code',
       redirect_uri: trustedClient.redirectUris[0],
       scope: `${Object.keys(oauthScopesConfig.scopes)[0]} ${Object.keys(oauthScopesConfig.scopes)[1]}`, // database:read database:write
@@ -1006,7 +1006,7 @@ test.group('OAuth JIT Organization Provisioning', (group) => {
 
     // Get initial tokens with organization context
     const authResponse = await client.get('/oauth/authorize').qs({
-      client_id: trustedClient.clientId,
+      client_id: trustedClient.id,
       response_type: 'code',
       redirect_uri: trustedClient.redirectUris[0],
       scope: Object.keys(oauthScopesConfig.scopes)[0], // database:read
@@ -1035,7 +1035,7 @@ test.group('OAuth JIT Organization Provisioning', (group) => {
     const idTokenHint = await createValidJWTWithOrganization(jwtData)
 
     const response = await client.get('/oauth/authorize').qs({
-      client_id: testClient.clientId,
+      client_id: testClient.id,
       response_type: 'code',
       redirect_uri: testClient.redirectUris[0],
       scope: Object.keys(oauthScopesConfig.scopes)[0], // database:read

--- a/tests/unit/services/oauth_authorization_code_grant_service.spec.ts
+++ b/tests/unit/services/oauth_authorization_code_grant_service.spec.ts
@@ -3,39 +3,32 @@ import sinon from 'sinon'
 import { DateTime } from 'luxon'
 import app from '@adonisjs/core/services/app'
 import OAuthAuthorizationCodeGrantService from '#services/oauth_authorization_code_grant_service'
-import CodeGeneratorService from '#services/code_generator_service'
 import OAuthTokenStorageService from '#services/oauth_token_storage_service'
 import OAuthAuthorizationCodeRepository from '#repositories/oauth_authorization_code_repository'
 import InvalidOAuthRequestException from '#exceptions/invalid_oauth_request_exception'
 import { OAuthTokenParams } from '#validators/oauth_token'
 import OAuthClient from '#models/oauth_client'
 import OAuthAuthorizationCode from '#models/oauth_authorization_code'
+import OAuthAccessToken from '#models/oauth_access_token'
+import OAuthRefreshToken from '#models/oauth_refresh_token'
 
 test.group('OAuthAuthorizationCodeGrantService | Unit', (group) => {
   let service: OAuthAuthorizationCodeGrantService
   let authCodeRepoStub: sinon.SinonStubbedInstance<OAuthAuthorizationCodeRepository>
-  let codeGeneratorStub: sinon.SinonStubbedInstance<CodeGeneratorService>
   let tokenStorageStub: sinon.SinonStubbedInstance<OAuthTokenStorageService>
 
   group.each.setup(() => {
     authCodeRepoStub = sinon.createStubInstance(OAuthAuthorizationCodeRepository)
-    codeGeneratorStub = sinon.createStubInstance(CodeGeneratorService)
     tokenStorageStub = sinon.createStubInstance(OAuthTokenStorageService)
 
     app.container.swap(OAuthAuthorizationCodeRepository, () => authCodeRepoStub as any)
-    app.container.swap(CodeGeneratorService, () => codeGeneratorStub as any)
     app.container.swap(OAuthTokenStorageService, () => tokenStorageStub as any)
 
-    service = new OAuthAuthorizationCodeGrantService(
-      authCodeRepoStub,
-      codeGeneratorStub,
-      tokenStorageStub
-    )
+    service = new OAuthAuthorizationCodeGrantService(authCodeRepoStub, tokenStorageStub)
   })
 
   group.each.teardown(() => {
     app.container.restore(OAuthAuthorizationCodeRepository)
-    app.container.restore(CodeGeneratorService)
     app.container.restore(OAuthTokenStorageService)
     sinon.restore()
   })
@@ -53,106 +46,78 @@ test.group('OAuthAuthorizationCodeGrantService | Unit', (group) => {
     }
 
     const client = {
-      clientId: 'test-client',
+      id: 'test-client-uuid',
       accessTokenLifetime: 3600,
       refreshTokenLifetime: 86400,
     } as OAuthClient
 
     const authCode = {
-      codeHash: 'hashed-code',
+      id: 'auth-code-uuid',
       userId: 'user-123',
       isUsed: false,
       expiresAt: DateTime.now().plus({ minutes: 10 }),
       scopes: ['database:read', 'database:write'],
     } as unknown as OAuthAuthorizationCode
 
-    const generatedTokens = {
-      accessToken: 'generated-access-token',
-      refreshToken: 'generated-refresh-token',
+    const storedTokens = {
+      accessTokenRecord: { id: 'access-token-uuid' } as OAuthAccessToken,
+      refreshTokenRecord: { id: 'refresh-token-uuid' } as OAuthRefreshToken,
     }
 
     // Setup stubs
     authCodeRepoStub.findAndValidate.resolves(authCode)
     authCodeRepoStub.markAsUsed.resolves()
-    codeGeneratorStub.generateTokenPair.returns(generatedTokens)
-    tokenStorageStub.storeTokens.resolves({} as any)
+    tokenStorageStub.storeTokens.resolves(storedTokens)
 
     // Execute
     const result = await service.handle(params, client)
 
     // Verify response
-    assert.equal(result.access_token, 'generated-access-token')
+    assert.equal(result.access_token, 'access-token-uuid')
     assert.equal(result.token_type, 'Bearer')
     assert.equal(result.expires_in, 3600)
-    assert.equal(result.refresh_token, 'generated-refresh-token')
+    assert.equal(result.refresh_token, 'refresh-token-uuid')
     assert.equal(result.scope, 'database:read database:write')
 
     // Verify method calls
-    assert.isTrue(
-      authCodeRepoStub.findAndValidate.calledOnceWith(
-        'valid-auth-code',
-        'test-client',
-        'https://client.app/callback'
-      )
-    )
-    assert.isTrue(authCodeRepoStub.markAsUsed.calledOnceWith('hashed-code'))
-    assert.isTrue(codeGeneratorStub.generateTokenPair.calledOnce)
+    assert.isTrue(authCodeRepoStub.findAndValidate.calledOnce)
+    assert.isTrue(authCodeRepoStub.markAsUsed.calledWith('auth-code-uuid'))
     assert.isTrue(tokenStorageStub.storeTokens.calledOnce)
-
-    // Verify token storage data
-    const storageArgs = tokenStorageStub.storeTokens.firstCall.args[0]
-    assert.equal(storageArgs.accessToken, 'generated-access-token')
-    assert.equal(storageArgs.refreshToken, 'generated-refresh-token')
-    assert.equal(storageArgs.clientId, 'test-client')
-    assert.equal(storageArgs.userId, 'user-123')
-    assert.deepEqual(storageArgs.scopes, ['database:read', 'database:write'])
-    assert.equal(storageArgs.accessTokenLifetime, 3600)
-    assert.equal(storageArgs.refreshTokenLifetime, 86400)
   })
 
-  test('handle :: should throw error when code parameter is missing', async ({ assert }) => {
+  test('handle :: should throw error when code is missing', async ({ assert }) => {
     const params: OAuthTokenParams = {
       grant_type: 'authorization_code',
       client_id: 'test-client',
       client_secret: 'test-secret',
       redirect_uri: 'https://client.app/callback',
-      // code is missing
     }
 
-    const client = { clientId: 'test-client' } as OAuthClient
+    const client = { id: 'test-client-uuid' } as OAuthClient
 
     try {
       await service.handle(params, client)
       assert.fail('Expected InvalidOAuthRequestException to be thrown')
     } catch (error) {
       assert.instanceOf(error, InvalidOAuthRequestException)
-      assert.equal(error.error, 'invalid_request')
-      assert.include(error.message, 'Missing code or redirect_uri')
-      assert.isFalse(authCodeRepoStub.findAndValidate.called)
     }
   })
 
-  test('handle :: should throw error when redirect_uri parameter is missing', async ({
-    assert,
-  }) => {
+  test('handle :: should throw error when redirect_uri is missing', async ({ assert }) => {
     const params: OAuthTokenParams = {
       grant_type: 'authorization_code',
       client_id: 'test-client',
       client_secret: 'test-secret',
       code: 'valid-auth-code',
-      // redirect_uri is missing
     }
 
-    const client = { clientId: 'test-client' } as OAuthClient
+    const client = { id: 'test-client-uuid' } as OAuthClient
 
     try {
       await service.handle(params, client)
       assert.fail('Expected InvalidOAuthRequestException to be thrown')
     } catch (error) {
       assert.instanceOf(error, InvalidOAuthRequestException)
-      assert.equal(error.error, 'invalid_request')
-      assert.include(error.message, 'Missing code or redirect_uri')
-      assert.isFalse(authCodeRepoStub.findAndValidate.called)
     }
   })
 
@@ -165,9 +130,8 @@ test.group('OAuthAuthorizationCodeGrantService | Unit', (group) => {
       redirect_uri: 'https://client.app/callback',
     }
 
-    const client = { clientId: 'test-client' } as OAuthClient
+    const client = { id: 'test-client-uuid' } as OAuthClient
 
-    // Setup stub to return null (code not found)
     authCodeRepoStub.findAndValidate.resolves(null)
 
     try {
@@ -175,9 +139,6 @@ test.group('OAuthAuthorizationCodeGrantService | Unit', (group) => {
       assert.fail('Expected InvalidOAuthRequestException to be thrown')
     } catch (error) {
       assert.instanceOf(error, InvalidOAuthRequestException)
-      assert.equal(error.error, 'invalid_grant')
-      assert.include(error.message, 'Invalid authorization code')
-      assert.isFalse(authCodeRepoStub.markAsUsed.called)
     }
   })
 
@@ -192,26 +153,21 @@ test.group('OAuthAuthorizationCodeGrantService | Unit', (group) => {
       redirect_uri: 'https://client.app/callback',
     }
 
-    const client = { clientId: 'test-client' } as OAuthClient
+    const client = { id: 'test-client-uuid' } as OAuthClient
 
-    const usedAuthCode = {
-      codeHash: 'hashed-code',
-      userId: 'user-123',
-      isUsed: true, // Already used
+    const authCode = {
+      id: 'auth-code-uuid',
+      isUsed: true,
       expiresAt: DateTime.now().plus({ minutes: 10 }),
-      scopes: ['database:read'],
     } as unknown as OAuthAuthorizationCode
 
-    authCodeRepoStub.findAndValidate.resolves(usedAuthCode)
+    authCodeRepoStub.findAndValidate.resolves(authCode)
 
     try {
       await service.handle(params, client)
       assert.fail('Expected InvalidOAuthRequestException to be thrown')
     } catch (error) {
       assert.instanceOf(error, InvalidOAuthRequestException)
-      assert.equal(error.error, 'invalid_grant')
-      assert.include(error.message, 'Authorization code already used')
-      assert.isFalse(authCodeRepoStub.markAsUsed.called)
     }
   })
 
@@ -224,110 +180,21 @@ test.group('OAuthAuthorizationCodeGrantService | Unit', (group) => {
       redirect_uri: 'https://client.app/callback',
     }
 
-    const client = { clientId: 'test-client' } as OAuthClient
+    const client = { id: 'test-client-uuid' } as OAuthClient
 
-    const expiredAuthCode = {
-      codeHash: 'hashed-code',
-      userId: 'user-123',
+    const authCode = {
+      id: 'auth-code-uuid',
       isUsed: false,
-      expiresAt: DateTime.now().minus({ minutes: 10 }), // Expired 10 minutes ago
-      scopes: ['database:read'],
+      expiresAt: DateTime.now().minus({ minutes: 10 }), // Expired
     } as unknown as OAuthAuthorizationCode
 
-    authCodeRepoStub.findAndValidate.resolves(expiredAuthCode)
+    authCodeRepoStub.findAndValidate.resolves(authCode)
 
     try {
       await service.handle(params, client)
       assert.fail('Expected InvalidOAuthRequestException to be thrown')
     } catch (error) {
       assert.instanceOf(error, InvalidOAuthRequestException)
-      assert.equal(error.error, 'invalid_grant')
-      assert.include(error.message, 'Authorization code expired')
-      assert.isFalse(authCodeRepoStub.markAsUsed.called)
     }
-  })
-
-  test('handle :: should handle authorization code with empty scopes', async ({ assert }) => {
-    const params: OAuthTokenParams = {
-      grant_type: 'authorization_code',
-      client_id: 'test-client',
-      client_secret: 'test-secret',
-      code: 'valid-auth-code',
-      redirect_uri: 'https://client.app/callback',
-    }
-
-    const client = {
-      clientId: 'test-client',
-      accessTokenLifetime: 3600,
-      refreshTokenLifetime: 86400,
-    } as OAuthClient
-
-    const authCode = {
-      codeHash: 'hashed-code',
-      userId: 'user-123',
-      isUsed: false,
-      expiresAt: DateTime.now().plus({ minutes: 10 }),
-      scopes: [], // Empty scopes
-    } as unknown as OAuthAuthorizationCode
-
-    const generatedTokens = {
-      accessToken: 'generated-access-token',
-      refreshToken: 'generated-refresh-token',
-    }
-
-    authCodeRepoStub.findAndValidate.resolves(authCode)
-    authCodeRepoStub.markAsUsed.resolves()
-    codeGeneratorStub.generateTokenPair.returns(generatedTokens)
-    tokenStorageStub.storeTokens.resolves({} as any)
-
-    const result = await service.handle(params, client)
-
-    assert.equal(result.scope, '') // Empty scope string
-
-    // Verify token storage was called with empty scopes
-    const storageArgs = tokenStorageStub.storeTokens.firstCall.args[0]
-    assert.deepEqual(storageArgs.scopes, [])
-  })
-
-  test('handle :: should handle authorization code with null scopes', async ({ assert }) => {
-    const params: OAuthTokenParams = {
-      grant_type: 'authorization_code',
-      client_id: 'test-client',
-      client_secret: 'test-secret',
-      code: 'valid-auth-code',
-      redirect_uri: 'https://client.app/callback',
-    }
-
-    const client = {
-      clientId: 'test-client',
-      accessTokenLifetime: 3600,
-      refreshTokenLifetime: 86400,
-    } as OAuthClient
-
-    const authCode = {
-      codeHash: 'hashed-code',
-      userId: 'user-123',
-      isUsed: false,
-      expiresAt: DateTime.now().plus({ minutes: 10 }),
-      scopes: null, // Null scopes
-    } as unknown as OAuthAuthorizationCode
-
-    const generatedTokens = {
-      accessToken: 'generated-access-token',
-      refreshToken: 'generated-refresh-token',
-    }
-
-    authCodeRepoStub.findAndValidate.resolves(authCode)
-    authCodeRepoStub.markAsUsed.resolves()
-    codeGeneratorStub.generateTokenPair.returns(generatedTokens)
-    tokenStorageStub.storeTokens.resolves({} as any)
-
-    const result = await service.handle(params, client)
-
-    assert.equal(result.scope, '') // Empty scope string for null scopes
-
-    // Verify token storage was called with empty array for null scopes
-    const storageArgs = tokenStorageStub.storeTokens.firstCall.args[0]
-    assert.deepEqual(storageArgs.scopes, [])
   })
 })

--- a/tests/unit/services/oauth_authorization_service.spec.ts
+++ b/tests/unit/services/oauth_authorization_service.spec.ts
@@ -33,7 +33,7 @@ test.group('OAuthAuthorizationService | Unit', (group) => {
 
     fakeUser = await UserFactory.make()
     fakeClient = await OAuthClientFactory.merge({
-      clientId: fakeParams.client_id,
+      id: fakeParams.client_id,
       isTrusted: false,
     }).make()
 
@@ -50,7 +50,7 @@ test.group('OAuthAuthorizationService | Unit', (group) => {
 
   test('authorize :: should auto-approve and redirect for trusted clients', async ({ assert }) => {
     const trustedClient = await OAuthClientFactory.merge({
-      clientId: fakeParams.client_id,
+      id: fakeParams.client_id,
       isTrusted: true,
     }).make()
     const expectedRedirectUrl = 'https://client.app/callback?code=new-code'
@@ -97,11 +97,7 @@ test.group('OAuthAuthorizationService | Unit', (group) => {
 
     const expectedScopes = ['database:read', 'database:write']
     assert.isTrue(
-      consentServiceStub.needsConsent.calledOnceWith(
-        fakeUser.id,
-        fakeClient.clientId,
-        expectedScopes
-      )
+      consentServiceStub.needsConsent.calledOnceWith(fakeUser.id, fakeClient.id, expectedScopes)
     )
     assert.isTrue(
       autoApprovalServiceStub.approve.calledOnceWith({
@@ -180,7 +176,7 @@ test.group('OAuthAuthorizationService | Unit', (group) => {
     assert.isTrue(
       consentServiceStub.needsConsent.calledOnceWith(
         fakeUser.id,
-        fakeClient.clientId,
+        fakeClient.id,
         ['database:read'] // Default scope
       )
     )

--- a/tests/unit/services/oauth_auto_approval_service.spec.ts
+++ b/tests/unit/services/oauth_auto_approval_service.spec.ts
@@ -3,8 +3,8 @@ import sinon from 'sinon'
 import { DateTime } from 'luxon'
 import app from '@adonisjs/core/services/app'
 import OAuthAutoApprovalService from '#services/oauth_auto_approval_service'
-import CodeGeneratorService from '#services/code_generator_service'
 import OAuthAuthorizationCodeRepository from '#repositories/oauth_authorization_code_repository'
+import OAuthAuthorizationCode from '#models/oauth_authorization_code'
 import User from '#models/user'
 import OAuthClient from '#models/oauth_client'
 import { OAuthParams } from '#validators/oauth_authorize'
@@ -12,138 +12,179 @@ import { OAuthParams } from '#validators/oauth_authorize'
 test.group('OAuthAutoApprovalService | Unit', (group) => {
   let service: OAuthAutoApprovalService
   let authCodeRepoStub: sinon.SinonStubbedInstance<OAuthAuthorizationCodeRepository>
-  let codeGeneratorStub: sinon.SinonStubbedInstance<CodeGeneratorService>
 
   group.each.setup(() => {
     authCodeRepoStub = sinon.createStubInstance(OAuthAuthorizationCodeRepository)
-    codeGeneratorStub = sinon.createStubInstance(CodeGeneratorService)
 
     app.container.swap(OAuthAuthorizationCodeRepository, () => authCodeRepoStub as any)
-    app.container.swap(CodeGeneratorService, () => codeGeneratorStub as any)
 
-    service = new OAuthAutoApprovalService(authCodeRepoStub, codeGeneratorStub)
+    service = new OAuthAutoApprovalService(authCodeRepoStub)
   })
 
   group.each.teardown(() => {
     app.container.restore(OAuthAuthorizationCodeRepository)
-    app.container.restore(CodeGeneratorService)
     sinon.restore()
   })
 
   test('approve :: should generate code and return valid redirect URL', async ({ assert }) => {
     const fakeUser = { id: 'user-1' } as User
     const fakeClient = {
-      clientId: 'client-1',
+      id: 'client-uuid-1',
       redirectUris: ['https://client.app/callback'],
     } as OAuthClient
     const fakeParams: OAuthParams = {
-      client_id: fakeClient.clientId,
+      client_id: fakeClient.id,
       response_type: 'code',
       redirect_uri: fakeClient.redirectUris[0],
       scope: 'openid profile',
       state: 'abc-123-def-456',
     }
     const scopes = ['openid', 'profile']
-    const generatedCode = 'generated-auth-code-123'
+    const createdAuthCode = {
+      id: 'auth-code-uuid-123',
+    } as OAuthAuthorizationCode
 
     // Setup stubs
-    codeGeneratorStub.generateAuthorizationCode.returns(generatedCode)
-    authCodeRepoStub.create.resolves({} as any)
+    authCodeRepoStub.create.resolves(createdAuthCode)
 
-    const redirectUrl = await service.approve({
+    // Execute
+    const result = await service.approve({
       user: fakeUser,
       client: fakeClient,
       params: fakeParams,
-      scopes: scopes,
+      scopes,
       organizationId: null,
     })
 
-    // Verify redirect URL structure
-    const url = new URL(redirectUrl)
-    assert.equal(url.origin + url.pathname, fakeClient.redirectUris[0])
-    assert.equal(url.searchParams.get('code'), generatedCode)
-    assert.equal(url.searchParams.get('state'), fakeParams.state)
+    // Verify
+    assert.equal(
+      result,
+      'https://client.app/callback?code=auth-code-uuid-123&state=abc-123-def-456'
+    )
 
-    // Verify code generator was called
-    assert.isTrue(codeGeneratorStub.generateAuthorizationCode.calledOnce)
-
-    // Verify repository create was called with correct data
+    // Verify repository call
     assert.isTrue(authCodeRepoStub.create.calledOnce)
-    const createCallArgs = authCodeRepoStub.create.firstCall.args[0]
-
-    assert.equal(createCallArgs.code, generatedCode)
-    assert.equal(createCallArgs.clientId, fakeClient.clientId)
-    assert.equal(createCallArgs.userId, fakeUser.id)
-    assert.equal(createCallArgs.organizationId, null)
-    assert.equal(createCallArgs.redirectUri, fakeParams.redirect_uri)
-    assert.deepEqual(createCallArgs.scopes, scopes)
-    assert.equal(createCallArgs.state, fakeParams.state)
-    assert.isTrue(DateTime.isDateTime(createCallArgs.expiresAt))
-    assert.isFalse(createCallArgs.isUsed)
+    const createCall = authCodeRepoStub.create.getCall(0)
+    assert.equal(createCall.args[0].clientId, 'client-uuid-1')
+    assert.equal(createCall.args[0].userId, 'user-1')
+    assert.equal(createCall.args[0].redirectUri, 'https://client.app/callback')
+    assert.deepEqual(createCall.args[0].scopes, ['openid', 'profile'])
+    assert.equal(createCall.args[0].state, 'abc-123-def-456')
+    assert.equal(createCall.args[0].isUsed, false)
+    assert.isNull(createCall.args[0].organizationId)
   })
 
-  test('approve :: should handle undefined state parameter', async ({ assert }) => {
+  test('approve :: should handle organization context', async ({ assert }) => {
     const fakeUser = { id: 'user-1' } as User
     const fakeClient = {
-      clientId: 'client-1',
+      id: 'client-uuid-1',
       redirectUris: ['https://client.app/callback'],
     } as OAuthClient
     const fakeParams: OAuthParams = {
-      client_id: fakeClient.clientId,
+      client_id: fakeClient.id,
       response_type: 'code',
       redirect_uri: fakeClient.redirectUris[0],
-      scope: 'openid profile',
-      // state is undefined
+      scope: 'database:read',
     }
-    const scopes = ['openid', 'profile']
-    const generatedCode = 'generated-auth-code-123'
+    const scopes = ['database:read']
+    const organizationId = 'org-uuid-123'
+    const createdAuthCode = {
+      id: 'auth-code-uuid-456',
+    } as OAuthAuthorizationCode
 
-    codeGeneratorStub.generateAuthorizationCode.returns(generatedCode)
-    authCodeRepoStub.create.resolves({} as any)
+    // Setup stubs
+    authCodeRepoStub.create.resolves(createdAuthCode)
 
-    const redirectUrl = await service.approve({
+    // Execute
+    const result = await service.approve({
       user: fakeUser,
       client: fakeClient,
       params: fakeParams,
-      scopes: scopes,
-      organizationId: null,
+      scopes,
+      organizationId,
     })
 
-    const url = new URL(redirectUrl)
-    assert.equal(url.searchParams.get('code'), generatedCode)
-    assert.isFalse(url.searchParams.has('state')) // state should not be in URL
+    // Verify
+    assert.equal(result, 'https://client.app/callback?code=auth-code-uuid-456')
 
-    // Verify repository was called with undefined state
-    const createCallArgs = authCodeRepoStub.create.firstCall.args[0]
-    assert.isUndefined(createCallArgs.state)
+    // Verify organization context passed
+    const createCall = authCodeRepoStub.create.getCall(0)
+    assert.equal(createCall.args[0].organizationId, 'org-uuid-123')
   })
 
-  test('approve :: should throw error if code generation fails', async ({ assert }) => {
+  test('approve :: should handle missing state parameter', async ({ assert }) => {
     const fakeUser = { id: 'user-1' } as User
-    const fakeClient = { clientId: 'client-1' } as OAuthClient
+    const fakeClient = {
+      id: 'client-uuid-1',
+      redirectUris: ['https://client.app/callback'],
+    } as OAuthClient
     const fakeParams: OAuthParams = {
-      client_id: fakeClient.clientId,
+      client_id: fakeClient.id,
       response_type: 'code',
-      redirect_uri: 'https://client.app/callback',
+      redirect_uri: fakeClient.redirectUris[0],
       scope: 'openid',
     }
     const scopes = ['openid']
+    const createdAuthCode = {
+      id: 'auth-code-uuid-789',
+    } as OAuthAuthorizationCode
 
-    const codeGenerationError = new Error('Code generation failed')
-    codeGeneratorStub.generateAuthorizationCode.throws(codeGenerationError)
+    // Setup stubs
+    authCodeRepoStub.create.resolves(createdAuthCode)
 
-    try {
-      await service.approve({
-        user: fakeUser,
-        client: fakeClient,
-        params: fakeParams,
-        scopes: scopes,
-        organizationId: null,
-      })
-      assert.fail('Expected an error to be thrown')
-    } catch (error) {
-      assert.equal(error.message, 'Code generation failed')
-      assert.isFalse(authCodeRepoStub.create.called)
+    // Execute
+    const result = await service.approve({
+      user: fakeUser,
+      client: fakeClient,
+      params: fakeParams,
+      scopes,
+      organizationId: null,
+    })
+
+    // Verify - no state parameter in URL
+    assert.equal(result, 'https://client.app/callback?code=auth-code-uuid-789')
+
+    // Verify state is undefined in repository call
+    const createCall = authCodeRepoStub.create.getCall(0)
+    assert.isUndefined(createCall.args[0].state)
+  })
+
+  test('approve :: should set proper expiration time', async ({ assert }) => {
+    const fakeUser = { id: 'user-1' } as User
+    const fakeClient = {
+      id: 'client-uuid-1',
+      redirectUris: ['https://client.app/callback'],
+    } as OAuthClient
+    const fakeParams: OAuthParams = {
+      client_id: fakeClient.id,
+      response_type: 'code',
+      redirect_uri: fakeClient.redirectUris[0],
+      scope: 'openid',
     }
+    const scopes = ['openid']
+    const createdAuthCode = {
+      id: 'auth-code-uuid-999',
+    } as OAuthAuthorizationCode
+
+    // Setup stubs
+    authCodeRepoStub.create.resolves(createdAuthCode)
+
+    // Execute
+    await service.approve({
+      user: fakeUser,
+      client: fakeClient,
+      params: fakeParams,
+      scopes,
+      organizationId: null,
+    })
+
+    // Verify expiration is set to ~10 minutes from now
+    const createCall = authCodeRepoStub.create.getCall(0)
+    const expiresAt = createCall.args[0].expiresAt
+    const tenMinutesFromNow = DateTime.now().plus({ minutes: 10 })
+    const timeDiff = Math.abs(expiresAt!.diff(tenMinutesFromNow, 'seconds').seconds)
+
+    // Should be within 5 seconds of 10 minutes from now
+    assert.isTrue(timeDiff < 5)
   })
 })

--- a/tests/unit/services/oauth_client_validator_service.spec.ts
+++ b/tests/unit/services/oauth_client_validator_service.spec.ts
@@ -46,11 +46,11 @@ test.group('OAuthClientValidatorService | Unit', (group) => {
     assert,
   }) => {
     const fakeClient = {
-      clientId: 'client-1',
+      id: 'client-uuid-1',
       redirectUris: ['https://client.app/correct-callback'],
-    } as OAuthClient
+    } as unknown as OAuthClient
     const fakeParams = {
-      client_id: fakeClient.clientId,
+      client_id: fakeClient.id,
       redirect_uri: 'https://client.app/wrong-callback',
     } as OAuthParams
     clientRepoStub.findById.resolves(fakeClient)
@@ -67,11 +67,11 @@ test.group('OAuthClientValidatorService | Unit', (group) => {
 
   test('validate :: should return the client on successful validation', async ({ assert }) => {
     const fakeClient = {
-      clientId: 'client-1',
+      id: 'client-uuid-1',
       redirectUris: ['https://client.app/callback'],
-    } as OAuthClient
+    } as unknown as OAuthClient
     const fakeParams = {
-      client_id: fakeClient.clientId,
+      client_id: fakeClient.id,
       redirect_uri: fakeClient.redirectUris[0],
     } as OAuthParams
     clientRepoStub.findById.resolves(fakeClient)
@@ -79,6 +79,6 @@ test.group('OAuthClientValidatorService | Unit', (group) => {
     const result = await service.validate(fakeParams)
 
     assert.deepEqual(result, fakeClient)
-    assert.isTrue(clientRepoStub.findById.calledOnceWith(fakeClient.clientId))
+    assert.isTrue(clientRepoStub.findById.calledOnceWith(fakeClient.id))
   })
 })

--- a/tests/unit/services/oauth_code_generator_service.spec.ts
+++ b/tests/unit/services/oauth_code_generator_service.spec.ts
@@ -2,51 +2,35 @@ import { test } from '@japa/runner'
 import CodeGeneratorService from '#services/code_generator_service'
 
 test.group('CodeGeneratorService', () => {
-  test('should generate an authorization code', async ({ assert }) => {
+  test('should generate a secure password', async ({ assert }) => {
     const service = new CodeGeneratorService()
-    const code = service.generateAuthorizationCode()
+    const password = service.generatePassword()
 
-    assert.isString(code)
-    assert.isAbove(code.length, 0)
+    assert.isString(password)
+    assert.equal(password.length, 16) // Default length
   })
 
-  test('should generate an access token', async ({ assert }) => {
+  test('should generate password with custom length', async ({ assert }) => {
     const service = new CodeGeneratorService()
-    const token = service.generateAccessToken()
+    const password = service.generatePassword(24)
 
-    assert.isString(token)
-    assert.isAbove(token.length, 0)
+    assert.isString(password)
+    assert.equal(password.length, 24)
   })
 
-  test('should generate a refresh token', async ({ assert }) => {
+  test('should generate MongoDB replica key', async ({ assert }) => {
     const service = new CodeGeneratorService()
-    const token = service.generateRefreshToken()
+    const replicaKey = service.generateMongoReplicaKey()
 
-    assert.isString(token)
-    assert.isAbove(token.length, 0)
+    assert.isString(replicaKey)
+    assert.equal(replicaKey.length, 12) // Base64 encoded 9 bytes = 12 chars
   })
 
-  test('should generate a token pair', async ({ assert }) => {
+  test('should generate unique passwords', async ({ assert }) => {
     const service = new CodeGeneratorService()
-    const { accessToken, refreshToken } = service.generateTokenPair()
+    const password1 = service.generatePassword()
+    const password2 = service.generatePassword()
 
-    assert.isString(accessToken)
-    assert.isString(refreshToken)
-    assert.isAbove(accessToken.length, 0)
-    assert.isAbove(refreshToken.length, 0)
-    assert.notEqual(accessToken, refreshToken)
-  })
-
-  test('should generate unique codes each time', async ({ assert }) => {
-    const service = new CodeGeneratorService()
-
-    const code1 = service.generateAuthorizationCode()
-    const code2 = service.generateAuthorizationCode()
-    const token1 = service.generateAccessToken()
-    const token2 = service.generateAccessToken()
-
-    assert.notEqual(code1, code2)
-    assert.notEqual(token1, token2)
-    assert.notEqual(code1, token1)
+    assert.notEqual(password1, password2)
   })
 })

--- a/tests/unit/services/oauth_consent_data_service.spec.ts
+++ b/tests/unit/services/oauth_consent_data_service.spec.ts
@@ -35,7 +35,7 @@ test.group('OAuthConsentDataService | Unit', (group) => {
     })
 
     fakeClient = await OAuthClientFactory.merge({
-      clientId: fakeParams.client_id,
+      id: fakeParams.client_id,
       clientName: 'Test Client',
     }).make()
 

--- a/tests/unit/services/oauth_token_service.spec.ts
+++ b/tests/unit/services/oauth_token_service.spec.ts
@@ -17,10 +17,10 @@ test.group('OAuthTokenService | Unit', (group) => {
   let refreshTokenGrantStub: sinon.SinonStubbedInstance<OAuthRefreshTokenGrantService>
 
   const mockClient = {
-    clientId: 'test-client',
+    id: 'test-client-uuid',
     accessTokenLifetime: 3600,
     refreshTokenLifetime: 86400,
-  } as OAuthClient
+  } as unknown as OAuthClient
 
   const authCodeTokenResponse = {
     access_token: 'auth-code-access-token',
@@ -246,7 +246,7 @@ test.group('OAuthTokenService | Unit', (group) => {
       redirect_uri: 'https://auth.app/callback',
     }
 
-    const authClient = { clientId: 'auth-client' } as OAuthClient
+    const authClient = { id: 'auth-client-uuid' } as unknown as OAuthClient
     clientValidatorStub.validateCredentials.resolves(authClient)
     authCodeGrantStub.handle.resolves(authCodeTokenResponse)
 
@@ -268,7 +268,7 @@ test.group('OAuthTokenService | Unit', (group) => {
       refresh_token: 'valid-refresh-token',
     }
 
-    const refreshClient = { clientId: 'refresh-client' } as OAuthClient
+    const refreshClient = { id: 'refresh-client-uuid' } as unknown as OAuthClient
     clientValidatorStub.validateCredentials.resolves(refreshClient)
     refreshTokenGrantStub.handle.resolves(refreshTokenResponse)
 

--- a/tests/unit/services/oauth_token_storage_service.spec.ts
+++ b/tests/unit/services/oauth_token_storage_service.spec.ts
@@ -39,8 +39,6 @@ test.group('OAuthTokenStorageService | Unit', (group) => {
 
   test('storeTokens :: should store both access and refresh tokens', async ({ assert }) => {
     const tokenData: TokenStorageData = {
-      accessToken: 'generated-access-token',
-      refreshToken: 'generated-refresh-token',
       clientId: 'test-client',
       userId: 'user-123',
       scopes: ['database:read', 'database:write'],
@@ -49,8 +47,7 @@ test.group('OAuthTokenStorageService | Unit', (group) => {
     }
 
     const mockAccessToken = {
-      tokenHash: 'access-token-hash',
-      token: 'generated-access-token',
+      id: 'access-token-uuid',
       clientId: 'test-client',
       userId: 'user-123',
       scopes: ['database:read', 'database:write'],
@@ -59,11 +56,10 @@ test.group('OAuthTokenStorageService | Unit', (group) => {
     } as unknown as OAuthAccessToken
 
     const mockRefreshToken = {
-      tokenHash: 'refresh-token-hash',
-      token: 'generated-refresh-token',
+      id: 'refresh-token-uuid',
       clientId: 'test-client',
       userId: 'user-123',
-      accessTokenHash: 'access-token-hash',
+      accessTokenId: 'access-token-uuid',
       scopes: ['database:read', 'database:write'],
       isRevoked: false,
       expiresAt: mockDateTime.plus({ seconds: 86400 }),
@@ -79,7 +75,6 @@ test.group('OAuthTokenStorageService | Unit', (group) => {
     // Verify access token creation
     assert.isTrue(accessTokenRepoStub.create.calledOnce)
     const accessTokenArgs = accessTokenRepoStub.create.firstCall.args[0]
-    assert.equal(accessTokenArgs.token, 'generated-access-token')
     assert.equal(accessTokenArgs.clientId, 'test-client')
     assert.equal(accessTokenArgs.userId, 'user-123')
     assert.deepEqual(accessTokenArgs.scopes, ['database:read', 'database:write'])
@@ -89,10 +84,9 @@ test.group('OAuthTokenStorageService | Unit', (group) => {
     // Verify refresh token creation
     assert.isTrue(refreshTokenRepoStub.create.calledOnce)
     const refreshTokenArgs = refreshTokenRepoStub.create.firstCall.args[0]
-    assert.equal(refreshTokenArgs.token, 'generated-refresh-token')
     assert.equal(refreshTokenArgs.clientId, 'test-client')
     assert.equal(refreshTokenArgs.userId, 'user-123')
-    assert.equal(refreshTokenArgs.accessTokenHash, 'access-token-hash')
+    assert.equal(refreshTokenArgs.accessTokenId, 'access-token-uuid')
     assert.deepEqual(refreshTokenArgs.scopes, ['database:read', 'database:write'])
     assert.isFalse(refreshTokenArgs.isRevoked)
     assert.isTrue(refreshTokenArgs.expiresAt!.equals(mockDateTime.plus({ seconds: 86400 })))
@@ -104,8 +98,6 @@ test.group('OAuthTokenStorageService | Unit', (group) => {
 
   test('storeTokens :: should handle empty scopes', async ({ assert }) => {
     const tokenData: TokenStorageData = {
-      accessToken: 'access-token',
-      refreshToken: 'refresh-token',
       clientId: 'test-client',
       userId: 'user-123',
       scopes: [], // Empty scopes
@@ -114,12 +106,12 @@ test.group('OAuthTokenStorageService | Unit', (group) => {
     }
 
     const mockAccessToken = {
-      tokenHash: 'access-token-hash',
+      id: 'access-token-uuid',
       scopes: [],
     } as unknown as OAuthAccessToken
 
     const mockRefreshToken = {
-      tokenHash: 'refresh-token-hash',
+      id: 'refresh-token-uuid',
       scopes: [],
     } as unknown as OAuthRefreshToken
 
@@ -140,8 +132,6 @@ test.group('OAuthTokenStorageService | Unit', (group) => {
 
   test('storeTokens :: should handle different token lifetimes', async ({ assert }) => {
     const tokenData: TokenStorageData = {
-      accessToken: 'short-lived-token',
-      refreshToken: 'long-lived-token',
       clientId: 'test-client',
       userId: 'user-123',
       scopes: ['database:read'],
@@ -149,8 +139,8 @@ test.group('OAuthTokenStorageService | Unit', (group) => {
       refreshTokenLifetime: 604800, // 7 days
     }
 
-    const mockAccessToken = { tokenHash: 'hash1' } as unknown as OAuthAccessToken
-    const mockRefreshToken = { tokenHash: 'hash2' } as unknown as OAuthRefreshToken
+    const mockAccessToken = { id: 'access-uuid-1' } as unknown as OAuthAccessToken
+    const mockRefreshToken = { id: 'refresh-uuid-1' } as unknown as OAuthRefreshToken
 
     accessTokenRepoStub.create.resolves(mockAccessToken)
     refreshTokenRepoStub.create.resolves(mockRefreshToken)
@@ -167,7 +157,6 @@ test.group('OAuthTokenStorageService | Unit', (group) => {
 
   test('storeAccessToken :: should store a single access token', async ({ assert }) => {
     const tokenData = {
-      accessToken: 'new-access-token',
       clientId: 'test-client',
       userId: 'user-123',
       scopes: ['database:read', 'database:admin'],
@@ -175,8 +164,7 @@ test.group('OAuthTokenStorageService | Unit', (group) => {
     }
 
     const mockAccessToken = {
-      tokenHash: 'new-access-token-hash',
-      token: 'new-access-token',
+      id: 'new-access-token-uuid',
       clientId: 'test-client',
       userId: 'user-123',
       scopes: ['database:read', 'database:admin'],
@@ -191,7 +179,6 @@ test.group('OAuthTokenStorageService | Unit', (group) => {
     // Verify access token creation
     assert.isTrue(accessTokenRepoStub.create.calledOnce)
     const accessTokenArgs = accessTokenRepoStub.create.firstCall.args[0]
-    assert.equal(accessTokenArgs.token, 'new-access-token')
     assert.equal(accessTokenArgs.clientId, 'test-client')
     assert.equal(accessTokenArgs.userId, 'user-123')
     assert.deepEqual(accessTokenArgs.scopes, ['database:read', 'database:admin'])
@@ -207,7 +194,6 @@ test.group('OAuthTokenStorageService | Unit', (group) => {
 
   test('storeAccessToken :: should handle minimal scopes', async ({ assert }) => {
     const tokenData = {
-      accessToken: 'minimal-token',
       clientId: 'minimal-client',
       userId: 'user-456',
       scopes: ['basic'],
@@ -215,7 +201,7 @@ test.group('OAuthTokenStorageService | Unit', (group) => {
     }
 
     const mockAccessToken = {
-      tokenHash: 'minimal-hash',
+      id: 'minimal-uuid',
       scopes: ['basic'],
     } as unknown as OAuthAccessToken
 
@@ -228,34 +214,34 @@ test.group('OAuthTokenStorageService | Unit', (group) => {
     assert.equal(result, mockAccessToken)
   })
 
-  test('revokeAccessToken :: should revoke access token by hash', async ({ assert }) => {
-    const tokenHash = 'access-token-hash-to-revoke'
+  test('revokeAccessToken :: should revoke access token by id', async ({ assert }) => {
+    const tokenId = 'access-token-id-to-revoke'
 
     accessTokenRepoStub.revoke.resolves()
 
-    await service.revokeAccessToken(tokenHash)
+    await service.revokeAccessToken(tokenId)
 
-    // Verify revocation was called with correct hash
-    assert.isTrue(accessTokenRepoStub.revoke.calledOnceWith(tokenHash))
+    // Verify revocation was called with correct id
+    assert.isTrue(accessTokenRepoStub.revoke.calledOnceWith(tokenId))
 
     // Verify refresh token repository was NOT called
     assert.isFalse(refreshTokenRepoStub.create.called)
   })
 
-  test('updateRefreshTokenAccessToken :: should update refresh token with new access token hash', async ({
+  test('updateRefreshTokenAccessToken :: should update refresh token with new access token id', async ({
     assert,
   }) => {
     const mockRefreshToken = {
-      accessTokenHash: 'old-access-token-hash',
+      accessTokenId: 'old-access-token-id',
       save: sinon.spy(),
     } as unknown as OAuthRefreshToken
 
-    const newAccessTokenHash = 'new-access-token-hash'
+    const newAccessTokenId = 'new-access-token-id'
 
-    await service.updateRefreshTokenAccessToken(mockRefreshToken, newAccessTokenHash)
+    await service.updateRefreshTokenAccessToken(mockRefreshToken, newAccessTokenId)
 
     // Verify refresh token was updated
-    assert.equal(mockRefreshToken.accessTokenHash, newAccessTokenHash)
+    assert.equal(mockRefreshToken.accessTokenId, newAccessTokenId)
 
     // Verify save was called
     const saveSpy = mockRefreshToken.save as sinon.SinonSpy
@@ -268,8 +254,6 @@ test.group('OAuthTokenStorageService | Unit', (group) => {
 
   test('storeTokens :: should handle repository errors gracefully', async ({ assert }) => {
     const tokenData: TokenStorageData = {
-      accessToken: 'error-token',
-      refreshToken: 'error-refresh',
       clientId: 'error-client',
       userId: 'error-user',
       scopes: ['error:scope'],
@@ -297,8 +281,6 @@ test.group('OAuthTokenStorageService | Unit', (group) => {
 
   test('storeTokens :: should handle refresh token creation failure', async ({ assert }) => {
     const tokenData: TokenStorageData = {
-      accessToken: 'success-token',
-      refreshToken: 'fail-refresh',
       clientId: 'test-client',
       userId: 'test-user',
       scopes: ['test:scope'],
@@ -307,7 +289,7 @@ test.group('OAuthTokenStorageService | Unit', (group) => {
     }
 
     const mockAccessToken = {
-      tokenHash: 'success-hash',
+      id: 'success-uuid',
     } as unknown as OAuthAccessToken
 
     // Access token succeeds, refresh token fails
@@ -328,38 +310,38 @@ test.group('OAuthTokenStorageService | Unit', (group) => {
   })
 
   test('revokeAccessToken :: should handle revocation errors', async ({ assert }) => {
-    const tokenHash = 'problematic-hash'
+    const tokenId = 'problematic-id'
     const revocationError = new Error('Token not found')
 
     accessTokenRepoStub.revoke.rejects(revocationError)
 
     try {
-      await service.revokeAccessToken(tokenHash)
+      await service.revokeAccessToken(tokenId)
       assert.fail('Expected error to be thrown')
     } catch (error) {
       assert.equal(error.message, 'Token not found')
     }
 
-    assert.isTrue(accessTokenRepoStub.revoke.calledOnceWith(tokenHash))
+    assert.isTrue(accessTokenRepoStub.revoke.calledOnceWith(tokenId))
   })
 
   test('updateRefreshTokenAccessToken :: should handle save errors', async ({ assert }) => {
     const mockRefreshToken = {
-      accessTokenHash: 'old-hash',
+      accessTokenId: 'old-id',
       save: sinon.stub().rejects(new Error('Save failed')),
     } as unknown as OAuthRefreshToken
 
-    const newAccessTokenHash = 'new-hash'
+    const newAccessTokenId = 'new-id'
 
     try {
-      await service.updateRefreshTokenAccessToken(mockRefreshToken, newAccessTokenHash)
+      await service.updateRefreshTokenAccessToken(mockRefreshToken, newAccessTokenId)
       assert.fail('Expected error to be thrown')
     } catch (error) {
       assert.equal(error.message, 'Save failed')
     }
 
-    // Verify the hash was still updated before save failed
-    assert.equal(mockRefreshToken.accessTokenHash, newAccessTokenHash)
+    // Verify the id was still updated before save failed
+    assert.equal(mockRefreshToken.accessTokenId, newAccessTokenId)
 
     // Verify save was attempted
     const saveStub = mockRefreshToken.save as sinon.SinonStub


### PR DESCRIPTION
Replace hashed token storage with UUID-based tokens in OAuth implementation for improved performance and simplified architecture.

  ### Why

  The OAuth system was using CPU-intensive hashing operations to validate tokens on every request, causing performance bottlenecks when multiple
  tokens needed validation. By switching to UUIDs as primary keys, we eliminate the need for hash comparisons entirely - tokens can be validated
  with direct database lookups using indexed UUID columns.

  ### How

  - Changed all OAuth token models to use UUID primary keys instead of hashed values
  - Removed hash generation and verification logic from repositories
  - Updated token storage to use auto-generated UUIDs from the database
  - Simplified token lookup methods to use direct ID queries instead of iterating through potential matches
  - Updated relationships between models to reference UUID fields directly

This change significantly improves query performance, especially for token validation operations that happen on every authenticated request.